### PR TITLE
Allow definition of http headers for outgoing requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # gqlx CLI Changelog
 
+## 0.3.0
+
+- Definition of static http headers for every outgoing request via `header` cli argument. See `gqlx-cli serve —help` for further details.
+
 ## 0.2.1
 
 - Updated dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gqlx-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gqlx-cli",
   "description": "Command line utility for GraphQL eXtended.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "main": "dist",
   "types": "dist",
   "license": "MIT",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,7 @@
-import { Request } from 'express';
+import { Request as ExpressRequest } from 'express';
 import { Service } from 'gqlx-apollo-express-server';
 import { subscribeTo } from './listener';
+import { RequestAPI, Request, Options, RequiredUriUrl } from 'request';
 import { createOptions, request, getFormData } from './io';
 import { ResolverApi, QueryOptions, MutationOptions, ServiceData } from '../types';
 
@@ -14,33 +15,37 @@ export const apiDefinition = {
   listen: false,
 };
 
-export function createApi(service: Service<ResolverApi, ServiceData>, req: Request | undefined): ResolverApi {
+export function createApi(
+  fetch: RequestAPI<Request, Options, RequiredUriUrl>,
+  service: Service<ResolverApi, ServiceData>,
+  req: ExpressRequest | undefined,
+): ResolverApi {
   return {
     del(url: string | QueryOptions) {
       const options = createOptions(service.data.url, url);
-      return request('DELETE', req, options);
+      return request(fetch, 'DELETE', req, options);
     },
     form(file: any, data: any) {
       return getFormData(file, data);
     },
     get(url: string | QueryOptions) {
       const options = createOptions(service.data.url, url);
-      return request('GET', req, options);
+      return request(fetch, 'GET', req, options);
     },
     query(url: string, q: string) {
       const options = createOptions(service.data.url, url, { query: q });
-      return request('POST', req, options);
+      return request(fetch, 'POST', req, options);
     },
     listen(topic: string) {
       return subscribeTo(topic);
     },
     post(url: string | MutationOptions, body?: any) {
       const options = createOptions(service.data.url, url, body);
-      return request('POST', req, options);
+      return request(fetch, 'POST', req, options);
     },
     put(url: string | MutationOptions, body?: any) {
       const options = createOptions(service.data.url, url, body);
-      return request('PUT', req, options);
+      return request(fetch, 'PUT', req, options);
     },
   };
 }

--- a/src/api/io.ts
+++ b/src/api/io.ts
@@ -1,5 +1,5 @@
-import * as fetch from 'request';
-import { Request } from 'express';
+import { RequestAPI, Request, Options, RequiredUriUrl } from 'request';
+import { Request as ExpressRequest } from 'express';
 import { resolve } from 'url';
 import { MutationOptions, QueryOptions } from '../types';
 
@@ -9,7 +9,12 @@ function parseUrl(host: string, path: string) {
   return resolve(host, path);
 }
 
-export function request(method: string, req: Request | undefined, options: MutationOptions) {
+export function request(
+  fetch: RequestAPI<Request, Options, RequiredUriUrl>,
+  method: string,
+  req: ExpressRequest | undefined,
+  options: MutationOptions,
+) {
   return new Promise((resolve, reject) => {
     const headers = (req && req.headers) || {};
 


### PR DESCRIPTION
Allows definition of static http headers for outgoing requests by using the header argument at startup.
See “gqlx-cli serve —help” for an example.

Signed-off-by: Johannes Tandler (CZ) <zojtandl@zeiss.com>